### PR TITLE
Add authentication support to GemTimesheetClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>cz.blackshark</groupId>
     <artifactId>timesheet-server2</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <properties>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <jasperreports.version>6.20.0</jasperreports.version>
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.15.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
 <!--        <mapstruct.version>1.5.3.Final</mapstruct.version>-->
     </properties>

--- a/src/main/kotlin/cz/blackshark/config/GemTimesheetConfig.kt
+++ b/src/main/kotlin/cz/blackshark/config/GemTimesheetConfig.kt
@@ -4,7 +4,7 @@ import io.smallrye.config.ConfigMapping
 
 @ConfigMapping(prefix = "gemts")
 interface GemTimesheetConfig {
-
+    fun url(): String
     fun username(): String
     fun password(): String
     fun drMaxProjectName(): String

--- a/src/main/kotlin/cz/blackshark/modules/gemts/exceptions/TimesheetLoginException.kt
+++ b/src/main/kotlin/cz/blackshark/modules/gemts/exceptions/TimesheetLoginException.kt
@@ -1,0 +1,4 @@
+package cz.blackshark.modules.gemts.exceptions
+
+open class TimesheetLoginException(msg: String): Exception(msg) {
+}

--- a/src/main/kotlin/cz/blackshark/modules/gemts/http/client/GemTimesheetClient.kt
+++ b/src/main/kotlin/cz/blackshark/modules/gemts/http/client/GemTimesheetClient.kt
@@ -1,28 +1,23 @@
 package cz.blackshark.modules.gemts.http.client
 
 import cz.blackshark.annotations.Logged
-import cz.blackshark.config.GemTimesheetConfig
 import cz.blackshark.modules.gemts.dto.TSListItemVO
 import cz.blackshark.modules.gemts.dto.TSProjectVO
 import cz.blackshark.modules.gemts.dto.WriteWorkLogRequestVo
+import cz.blackshark.modules.gemts.service.GemTimesheetLogin
 import cz.blackshark.modules.jira.customizations.JiraClientObjectMapper
 import cz.blackshark.modules.main.http.provider.ResteasyWebApplicationExceptionMapper
-import io.smallrye.config.SmallRyeConfig
-import org.eclipse.microprofile.config.ConfigProvider
-import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.annotation.RegisterProviders
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
-import java.util.*
+import javax.ws.rs.CookieParam
+import javax.ws.rs.FormParam
 import javax.ws.rs.GET
 import javax.ws.rs.POST
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
+import javax.ws.rs.core.Response
 
-@ClientHeaderParam(
-    name = "Authorization",
-    value = ["{cz.blackshark.modules.gemts.http.client.GemTimesheetClient.auth}"]
-)
 @RegisterRestClient(configKey = "gem-timesheet")
 @Path("/rest")
 @RegisterProviders(
@@ -33,23 +28,21 @@ import javax.ws.rs.QueryParam
 @Logged
 interface GemTimesheetClient {
 
-    fun auth(): String {
-        val config = ConfigProvider.getConfig().unwrap(SmallRyeConfig::class.java)
-        val timesheet = config.getConfigMapping(GemTimesheetConfig::class.java)
-        val username = timesheet.username()
-        val password = timesheet.password()
-        return "Basic " + Base64.getEncoder().encodeToString("$username:$password".toByteArray())
-    }
-
     @GET
     @Path("timesheets")
-    fun workLog(@QueryParam("monthCode") monthCode: String): List<TSListItemVO>
+    fun workLog(
+        @QueryParam("monthCode") monthCode: String,
+        @CookieParam(GemTimesheetLogin.QUAKRUS_COOKIE_LOGIN_NAME) cookie: String,
+    ): List<TSListItemVO>
 
     @GET
     @Path("projects/fullProjectsStructure")
-    fun getRootProjects(): List<TSProjectVO>
+    fun getRootProjects(@CookieParam(GemTimesheetLogin.QUAKRUS_COOKIE_LOGIN_NAME) cookie: String): List<TSProjectVO>
 
     @POST
     @Path("/timesheets")
-    fun saveWorkLog(data: WriteWorkLogRequestVo): List<WriteWorkLogRequestVo>
+    fun saveWorkLog(
+        data: WriteWorkLogRequestVo,
+        @CookieParam(GemTimesheetLogin.QUAKRUS_COOKIE_LOGIN_NAME) cookie: String,
+    ): List<WriteWorkLogRequestVo>
 }

--- a/src/main/kotlin/cz/blackshark/modules/gemts/http/client/GemTimesheetLoginClient.kt
+++ b/src/main/kotlin/cz/blackshark/modules/gemts/http/client/GemTimesheetLoginClient.kt
@@ -1,0 +1,43 @@
+package cz.blackshark.modules.gemts.http.client
+
+import cz.blackshark.config.GemTimesheetConfig
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import javax.enterprise.context.ApplicationScoped
+import javax.ws.rs.core.MediaType
+
+@ApplicationScoped
+class GemTimesheetLoginClient(
+    private val gmConfig: GemTimesheetConfig
+) {
+
+    private val client = HttpClient.newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build()
+
+    fun login(username: String, password: String): HttpResponse<Void> {
+
+        val request = HttpRequest
+            .newBuilder()
+            .uri(URI(gmConfig.url() + "/j_security_check"))
+            .POST(HttpRequest.BodyPublishers.ofString(buildData(username, password)))
+            .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED)
+            .build()
+
+        return client.send(request, HttpResponse.BodyHandlers.discarding())
+    }
+
+    private fun buildData(username: String, password: String): String {
+        val data = mapOf(
+            "j_username" to username,
+            "j_password" to password
+        )
+        return data.map { "${it.key}=${URLEncoder.encode(it.value, "UTF-8")}" }
+            .joinToString("&")
+    }
+}

--- a/src/main/kotlin/cz/blackshark/modules/gemts/service/GemTimesheetLogin.kt
+++ b/src/main/kotlin/cz/blackshark/modules/gemts/service/GemTimesheetLogin.kt
@@ -1,0 +1,79 @@
+package cz.blackshark.modules.gemts.service
+
+import cz.blackshark.config.GemTimesheetConfig
+import cz.blackshark.modules.gemts.exceptions.TimesheetLoginException
+import cz.blackshark.modules.gemts.http.client.GemTimesheetLoginClient
+import io.quarkus.logging.Log
+import java.net.HttpCookie
+import java.net.http.HttpResponse
+import java.time.LocalDateTime
+import javax.enterprise.context.ApplicationScoped
+
+@ApplicationScoped
+class GemTimesheetLogin(
+    private val tsConfig: GemTimesheetConfig,
+    private val client: GemTimesheetLoginClient,
+) {
+
+    companion object {
+        const val QUAKRUS_COOKIE_LOGIN_NAME: String = "quarkus-credential"
+    }
+
+    private var cookieValue: String? = null
+    private var lastLogin: LocalDateTime? = null
+
+    @Throws(TimesheetLoginException::class)
+    fun login(): String? {
+        Log.info("Process login into GEM Timesheet!")
+        val response = client.login(tsConfig.username(), tsConfig.password())
+        cookieValue = when (response.statusCode()) {
+            302 -> {
+                processProbablyValidResponse(response).also { lastLogin = LocalDateTime.now() }
+            }
+            else -> processUnexpectedResponse(response)
+        }
+        return cookieValue
+    }
+
+    private fun processUnexpectedResponse(response: HttpResponse<Void>): String? {
+        throw TimesheetLoginException("Unexpected response from login endpoint. Expected HTTP status 302 but ${response.statusCode()} received.")
+    }
+
+    private fun processProbablyValidResponse(response: HttpResponse<Void>): String {
+        val location = response.headers().firstValue("Location")
+
+        if (location.isPresent) {
+            val strLoc = location.get()
+            if (strLoc.contains("error")) {
+                throw TimesheetLoginException("Login failed. Redirect location is error page!")
+            }
+
+            val cookies: MutableList<HttpCookie> = mutableListOf()
+            response.headers().map().entries.filter { it.key.equals("Set-Cookie", true) }
+                .forEach { mapEntry ->
+                    mapEntry.value.forEach {
+                        cookieStr ->
+                        cookies.addAll(HttpCookie.parse(cookieStr))
+                    }
+                }
+            return cookies.firstOrNull { it.name == QUAKRUS_COOKIE_LOGIN_NAME }?.value ?: ""
+
+        } else {
+            throw TimesheetLoginException("Header location not present in login response")
+        }
+
+    }
+
+    fun getCookie(): String? {
+        if (lastLogin == null || lastLogin!!.isBefore(LocalDateTime.now().minusMinutes(25)) || lastLogin == null) {
+            Log.info("Expired login. Try re-login!")
+            try {
+                login()
+            } catch (e: Exception) {
+                Log.error("Login to GEM Timesheet failed: ${e.message}")
+            }
+        }
+        Log.info("Login cookie: $cookieValue")
+        return cookieValue
+    }
+}

--- a/src/main/kotlin/cz/blackshark/modules/main/http/filter/LoggingFilter.kt
+++ b/src/main/kotlin/cz/blackshark/modules/main/http/filter/LoggingFilter.kt
@@ -42,7 +42,13 @@ class LoggingFilter : ContainerRequestFilter, ContainerResponseFilter, WriterInt
         try {
             context.proceed()
         } finally {
-            logger.tracef("Response Data: %s", baos.toString("UTF-8"))
+            val data = baos.toString("UTF-8")
+            if (data.contains("password")) {
+                logger.trace("Response Data: <***>")
+            } else {
+                logger.tracef("Response Data: %s", data)
+            }
+
             baos.writeTo(orginalStream)
             baos.close()
             context.outputStream = orginalStream

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,10 +43,10 @@ quarkus:
       level: INFO
       format: "%d{YYYY-MM-DD'T'HH:mm:ss} %-5p %X{X-Correlation-Id} [%c{2.}] (%t) %s%e%n"
     category:
-      "cz.blackshark.http.filter":
-        level: WARN
+      "cz.blackshark.modules.main.http.filter":
+        level: INFO
       "org.jboss.resteasy.client":
-        level: WARN
+        level: INFO
     file:
       enable: true
       level: INFO
@@ -68,6 +68,7 @@ jira:
   token: ${JIRA_TOKEN}
   account-id: ${JIRA_ACCOUNT_ID}
 gemts:
+  url: ${GEM_TIMESHEET_URL}
   username: ${TIMESHEET_USERNAME}
   password: ${TIMESHEET_PASSWORD}
   dr-max-project-name: "DrMax integrační platforma"

--- a/src/main/webapp/src/router/index.ts
+++ b/src/main/webapp/src/router/index.ts
@@ -26,9 +26,6 @@ const routes: Array<RouteRecordRaw> = [
     {
         path: '/about',
         name: 'About',
-        // route level code-splitting
-        // this generates a separate chunk (about.[hash].js) for this route
-        // which is lazy-loaded when the route is visited.
         component: () => import(/* webpackChunkName: "about" */ '../views/About.vue')
     },
     {

--- a/src/test/kotlin/cz/blackshark/GemTimesheetTest.kt
+++ b/src/test/kotlin/cz/blackshark/GemTimesheetTest.kt
@@ -27,7 +27,7 @@ class GemTimesheetTest {
 
     @Test
     fun getTimelistTest() {
-        val data = client.workLog("2021/11")
+        val data = client.workLog("2021/11", "")
         Assertions.assertNotNull(data)
         Assertions.assertTrue(data.isNotEmpty())
         println(data)
@@ -35,7 +35,7 @@ class GemTimesheetTest {
 
     @Test
     fun getProjects() {
-        val data = client.getRootProjects()
+        val data = client.getRootProjects("")
         Assertions.assertNotNull(data)
         Assertions.assertTrue(data.isNotEmpty())
         println(data)

--- a/src/test/kotlin/cz/blackshark/modules/gemts/http/client/GemLoginClientTest.kt
+++ b/src/test/kotlin/cz/blackshark/modules/gemts/http/client/GemLoginClientTest.kt
@@ -1,0 +1,35 @@
+package cz.blackshark.modules.gemts.http.client
+
+import cz.blackshark.config.GemTimesheetConfig
+import cz.blackshark.modules.gemts.service.GemTimesheetLogin
+import io.quarkus.logging.Log
+import io.quarkus.test.junit.QuarkusTest
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@QuarkusTest
+class GemLoginClientTest {
+
+    @RestClient
+    private lateinit var gemTimesheetLoginClient: GemTimesheetLoginClient
+
+    @Inject
+    private lateinit var config: GemTimesheetConfig
+
+    @Test
+    fun `login should pass with valid username and password`() {
+        Log.info("Try login with user ${config.username()}")
+        try {
+            val response = gemTimesheetLoginClient.login(config.username(), config.password())
+            Assertions.assertNotNull(response)
+            Assertions.assertEquals(302, response.statusCode())
+//            Assertions.assertTrue(response.cookies.contains(GemTimesheetLogin.QUAKRUS_COOKIE_LOGIN_NAME))
+        } catch (e: Exception ) {
+            Log.error("Error during login", e)
+            Assertions.fail("Error during login",e)
+        }
+    }
+
+}


### PR DESCRIPTION
A new "GemTimesheetLogin" class has been added, with support to handle login process and provide authentication cookie. This cookie is now required in the API requests made by the "GemTimesheetClient". Also added logging of client request entities and changed HTTP request logging to conceal password information.